### PR TITLE
Upgrade for Mojo 24.1

### DIFF
--- a/clip.mojo
+++ b/clip.mojo
@@ -10,7 +10,7 @@ struct ClipEmbedding:
 
     fn __init__(inout self, n_vocab: Int, n_embed: Int, n_token: Int):
         self.token_embedding = Embedding(n_vocab, n_embed)
-        let pos_embed_matrix = Matrix[float_dtype](1, n_token, n_embed)
+        var pos_embed_matrix = Matrix[float_dtype](1, n_token, n_embed)
         pos_embed_matrix *= 0
         self.position_embedding = pos_embed_matrix
 
@@ -89,7 +89,7 @@ struct CLIP:
         # Here, we do not convert "state" to the long type (float64)for simplicity in Mojo type handling, but in production it would be useful to implement these functions with type float64 instead of float32 for greater precision
         var reshaped_tokens = Matrix[float_dtype](1, 1, 77)
         reshaped_tokens *= 0
-        reshaped_tokens.set_items(0, 0, slice(0, tokens.dim2), tokens)
+        reshaped_tokens.set_items(0, 0, Slice(0, tokens.dim2), tokens)
         var state = self.embedding.forward(reshaped_tokens)
         state = self.player1.forward(state)
         state = self.player2.forward(state)

--- a/demo.mojo
+++ b/demo.mojo
@@ -1,16 +1,16 @@
 import pipeline
 from helpers.utils import *
 fn main() raises -> None:
-    let prompt = "a cat flying a spaceship"
-    let backup_prompt = ''
-    let input_image = Matrix[float_dtype](1, 512, 512)
-    let do_cfg = False
-    let cfg_scale = 0.8
-    let strength = 0.9
-    let num_inference_steps = 1
-    let seed = 40
+    var prompt = "a cat flying a spaceship"
+    var backup_prompt = ''
+    var input_image = Matrix[float_dtype](1, 512, 512)
+    var do_cfg = False
+    var cfg_scale = 0.8
+    var strength = 0.9
+    var num_inference_steps = 1
+    var seed = 40
 
-    let output_image = pipeline.generate(
+    var output_image = pipeline.generate(
     prompt=prompt,
     backup_prompt=backup_prompt,
     strength=strength,

--- a/diffusion.mojo
+++ b/diffusion.mojo
@@ -85,7 +85,7 @@ struct Unet_Attention_Block:
     var layer10: Conv2D
 
     fn __init__(inout self, n_head: Int, n_embed: Int, d_context: Int = 768):
-        let channels = n_head * n_embed
+        var channels = n_head * n_embed
         self.layer1 = GroupNorm(32, channels, epsilon=1e-6)
         self.layer2 = Conv2D(channels, channels, 1, (0, 0))
         self.layer3 = LayerNorm(channels)
@@ -112,7 +112,7 @@ struct Unet_Attention_Block:
     fn forward(
         inout self, x: Matrix[float_dtype], inout context: Matrix[float_dtype]
     ) -> Matrix[float_dtype]:
-        let residue_long = x
+        var residue_long = x
         var out = self.layer1.forward(x)
         out = self.layer2.forward(out)
         out = out.reshape(1, out.dim0, out.dim1 * out.dim2)
@@ -135,7 +135,7 @@ struct Unet_Attention_Block:
         out = out.transpose(0, 2)
         out = self.layer7.forward(out)
         out = out.transpose(0, 2)
-        let chunked_linear = self.layer8.forward(out).chunk(2, 2)
+        var chunked_linear = self.layer8.forward(out).chunk(2, 2)
         out = chunked_linear[0]
         var gate = chunked_linear[1]
         out = out.transpose(1, 2)
@@ -144,8 +144,8 @@ struct Unet_Attention_Block:
 
         ## In these lines, I am concatenating the "out" variable multiple times because the latent space dimension (128 rows here) is much smaller than the "residue short" variable, which was constructed from a real Stable Diffusion tokenizer (which is why it has 4096 rows).
         # However, this should not be done in production. The correct approach is either to use a smaller tokenizer or a larger latent space.
-        let original_out = out
-        let diff = residue_short.dim1 // out.dim1 - 1
+        var original_out = out
+        var diff = residue_short.dim1 // out.dim1 - 1
         if diff > 0:
             for _ in range(residue_short.dim1 // out.dim1 - 1):
                 out = out.concat(original_out, 1)
@@ -228,7 +228,7 @@ struct UNet:
         inout context: Matrix[float_dtype],
         inout time: Matrix[float_dtype],
     ) -> Matrix[float_dtype]:
-        
+
         # Encoders
         var out = self.layer1.forward(x)
         var skip1 = out

--- a/helpers/attention.mojo
+++ b/helpers/attention.mojo
@@ -48,13 +48,13 @@ struct Self_Attention:
         if causal_mask:
             var mask = Matrix[float_dtype](weight.dim0, weight.dim1, weight.dim2)
             mask.set_items(
-                slice(0, mask.dim0), slice(0, mask.dim1), slice(0, mask.dim2), 1
+                Slice(0, mask.dim0), Slice(0, mask.dim1), Slice(0, mask.dim2), 1
             )
             mask = mask.triu(1)
-            let neg_inf = math.limit.neginf[float_dtype]()
+            var neg_inf = math.limit.neginf[float_dtype]()
             weight = weight.masked_fill(mask, neg_inf)
 
-        let head_float: Float32 = x.dim2 // self.n_heads
+        var head_float: Float32 = x.dim2 // self.n_heads
         weight = weight / math.sqrt(head_float)
         weight = Softmax(weight, dim=2)
         var output = weight.matmul(v)
@@ -107,7 +107,7 @@ struct Cross_Attention:
         v = v.reshape(v.dim0 * self.n_heads, v.dim1, v.dim2 // self.n_heads)
 
         var weight = q.matmul(k.transpose(1, 2))
-        let head_float: Float32 = x.dim2 // self.n_heads
+        var head_float: Float32 = x.dim2 // self.n_heads
         weight = weight / math.sqrt(head_float)
         weight = Softmax(weight, dim=2)
         var output = weight.matmul(v)

--- a/pipeline.mojo
+++ b/pipeline.mojo
@@ -34,19 +34,19 @@ fn generate(
     # Using a vocab size of 49408, since we rely on the CLIP Tokenizer
     var tokenizer = Tokenizer(49408, tokenizer_buffer)
     var context: Matrix[float_dtype]
-    let processed_prompt = prompt.replace(" ", "</w>")
-    let processed_backup = backup_prompt.replace(" ", "</w>")
+    var processed_prompt = prompt.replace(" ", "</w>")
+    var processed_backup = backup_prompt.replace(" ", "</w>")
     if cfg:
         var prompt_tokens = DynamicVector[Int]()
-        let cond_tokens_vector = bpe_encode(processed_prompt, tokenizer)
+        var cond_tokens_vector = bpe_encode(processed_prompt, tokenizer)
         var cond_tokens = vector_to_matrix(cond_tokens_vector)
         var cond_context = clip.forward(cond_tokens)
-        let backup_tokens_vector = bpe_encode(processed_backup, tokenizer)
+        var backup_tokens_vector = bpe_encode(processed_backup, tokenizer)
         var backup_tokens = vector_to_matrix(backup_tokens_vector)
-        let backup_context = clip.forward(backup_tokens)
+        var backup_context = clip.forward(backup_tokens)
         context = cond_context.concat(backup_context, dim=0)
     else:
-        let tokens_vector = bpe_encode(processed_prompt, tokenizer)
+        var tokens_vector = bpe_encode(processed_prompt, tokenizer)
         var tokens = vector_to_matrix(tokens_vector)
         context = clip.forward(tokens)
 
@@ -55,7 +55,7 @@ fn generate(
     var sampler = DDPMSampler(seed_val)
     sampler.set_inference_timesteps(inference_steps)
 
-    let latents_shape = (4, 64, 64)
+    var latents_shape = (4, 64, 64)
     var latents = Matrix[float_dtype](
         Tuple.get[0, Int](latents_shape),
         Tuple.get[1, Int](latents_shape),
@@ -65,7 +65,7 @@ fn generate(
         var encoder = Encoder()
         print("Encoder instance created")
         var resized_input = resize_image(input_image, 512, 512)
-        let rescaled_input = resized_input.rescale((0, 255), (-1, 1))
+        var rescaled_input = resized_input.rescale((0, 255), (-1, 1))
         var encoder_noise = Matrix[float_dtype](
             Tuple.get[0, Int](latents_shape),
             Tuple.get[1, Int](latents_shape),
@@ -78,13 +78,13 @@ fn generate(
         latents = sampler.add_noise(latents, sampler.timesteps[0])
     else:
         latents.init_weights_seed(seed_val)
-    
+
     var diffusion = Diffusion()
     print("Diffusion instance created")
 
-    let num_timesteps = sampler.timesteps.num_elements()
+    var num_timesteps = sampler.timesteps.num_elements()
     for i in range(num_timesteps):
-        let timestep = sampler.timesteps[i]
+        var timestep = sampler.timesteps[i]
         var time_embedding = get_time_embedding(timestep)
         var model_input = latents
         if cfg:
@@ -93,10 +93,10 @@ fn generate(
         var model_output = diffusion.forward(model_input, context, time_embedding)
 
         if cfg:
-            let chunked_output = model_output.chunk(0, 2)
-            let conditional_output = chunked_output[0]
-            let backup_output = chunked_output[1]
-            let cfg_scale_f32 = SIMD[DType.float32, 1].splat(
+            var chunked_output = model_output.chunk(0, 2)
+            var conditional_output = chunked_output[0]
+            var backup_output = chunked_output[1]
+            var cfg_scale_f32 = SIMD[DType.float32, 1].splat(
                 cfg_scale.cast[DType.float32]()
             )
             model_output = (

--- a/sampler.mojo
+++ b/sampler.mojo
@@ -37,8 +37,8 @@ struct DDPMSampler:
         num_inference_steps: Int = 1,
     ):
         self.num_inference_steps = num_inference_steps
-        let step_ratio: Float32 = self.num_training_steps // self.num_inference_steps
-        let timesteps = round_tensor(
+        var step_ratio: Float32 = self.num_training_steps // self.num_inference_steps
+        var timesteps = round_tensor(
             arange(0, self.num_inference_steps, True) * step_ratio
         )
         self.timesteps = timesteps
@@ -47,17 +47,17 @@ struct DDPMSampler:
         inout self,
         timestep: Int,
     ) -> Int:
-        let prev_t = timestep - self.num_training_steps // self.num_inference_steps
+        var prev_t = timestep - self.num_training_steps // self.num_inference_steps
         return prev_t
 
     fn get_variance(
         inout self,
         timestep: Int,
     ) -> Float32:
-        let prev_t = self.get_previous_timestep(timestep)
-        let alpha_prod_t = self.alphas_cumprod[timestep]
-        let alpha_prod_t_prev = self.alphas_cumprod[prev_t] if prev_t >= 0 else 1
-        let current_beta_t = 1 - alpha_prod_t / alpha_prod_t_prev
+        var prev_t = self.get_previous_timestep(timestep)
+        var alpha_prod_t = self.alphas_cumprod[timestep]
+        var alpha_prod_t_prev = self.alphas_cumprod[prev_t] if prev_t >= 0 else 1
+        var current_beta_t = 1 - alpha_prod_t / alpha_prod_t_prev
         var variance = (1 - alpha_prod_t_prev) / (1 - alpha_prod_t) * current_beta_t
 
         # Preventing zero values
@@ -65,10 +65,10 @@ struct DDPMSampler:
         return variance[0]
 
     fn set_strength(inout self, strength: Float32):
-        let start_step = self.num_inference_steps - int(
+        var start_step = self.num_inference_steps - int(
             self.num_inference_steps * strength
         )
-        let timesteps_length = self.timesteps.num_elements()
+        var timesteps_length = self.timesteps.num_elements()
         self.timesteps = get_tensor_values(self.timesteps, start_step, timesteps_length)
         self.start_step = start_step
 
@@ -78,22 +78,22 @@ struct DDPMSampler:
         latents: Matrix[float_dtype],
         model_output: Matrix[float_dtype],
     ) -> Matrix[float_dtype]:
-        let prev_t = self.get_previous_timestep(timestep)
-        let alpha_prod = self.alphas_cumprod[timestep]
-        let alpha_prod_prev = self.alphas_cumprod[prev_t] if prev_t >= 0 else 1
-        let beta_prod = 1 - alpha_prod
-        let beta_prod_prev = 1 - alpha_prod_prev
-        let current_alpha = alpha_prod / alpha_prod_prev
-        let current_beta = 1 - current_alpha
-        let alpha_prod_final = alpha_prod[0]
-        let beta_prod_final = beta_prod[0]
-        let pred_original_sample = (
+        var prev_t = self.get_previous_timestep(timestep)
+        var alpha_prod = self.alphas_cumprod[timestep]
+        var alpha_prod_prev = self.alphas_cumprod[prev_t] if prev_t >= 0 else 1
+        var beta_prod = 1 - alpha_prod
+        var beta_prod_prev = 1 - alpha_prod_prev
+        var current_alpha = alpha_prod / alpha_prod_prev
+        var current_beta = 1 - current_alpha
+        var alpha_prod_final = alpha_prod[0]
+        var beta_prod_final = beta_prod[0]
+        var pred_original_sample = (
             latents - (model_output) * (beta_prod_final ** (0.5))
         ) / (alpha_prod_final ** (0.5))
-        let pred_original_sample_coefficient: Float32 = (
+        var pred_original_sample_coefficient: Float32 = (
             alpha_prod_prev ** (0.5) * current_beta
         ) / beta_prod
-        let current_sample_coefficient = current_alpha ** (
+        var current_sample_coefficient = current_alpha ** (
             0.5
         ) * beta_prod_prev / beta_prod
         var pred_previous_sample = pred_original_sample * pred_original_sample_coefficient + latents * current_sample_coefficient
@@ -103,26 +103,26 @@ struct DDPMSampler:
                 model_output.dim0, model_output.dim1, model_output.dim2
             )
             noise.init_weights_seed(self.seed_val)
-            let multiplier = (self.get_variance(timestep) ** 0.5)
-            let variance = noise * multiplier
+            var multiplier = (self.get_variance(timestep) ** 0.5)
+            var variance = noise * multiplier
             pred_previous_sample = pred_previous_sample + variance
         return pred_previous_sample
 
     fn add_noise(
         inout self, original_samples: Matrix[float_dtype], timestep: Float32
     ) -> Matrix[float_dtype]:
-        let int_timestep = int(timestep)
-        let sqrt_alpha_prod = self.alphas_cumprod[int_timestep] ** 0.5
+        var int_timestep = int(timestep)
+        var sqrt_alpha_prod = self.alphas_cumprod[int_timestep] ** 0.5
         var sqrt_alpha_prod_matrix = Matrix[float_dtype](1, 1, 1)
         sqrt_alpha_prod_matrix[0, 0, 0] = sqrt_alpha_prod[0]
-        let sqrt_one_minus_alpha_prod = (1 - self.alphas_cumprod[int_timestep]) ** 0.5
+        var sqrt_one_minus_alpha_prod = (1 - self.alphas_cumprod[int_timestep]) ** 0.5
         var sqrt_one_minus_alpha_prod_matrix = Matrix[float_dtype](1, 1, 1)
         sqrt_one_minus_alpha_prod_matrix[0, 0, 0] = sqrt_one_minus_alpha_prod[0]
         var noise = Matrix[float_dtype](
             original_samples.dim0, original_samples.dim1, original_samples.dim2
         )
         noise.init_weights_seed(self.seed_val)
-        let noisy_samples = sqrt_alpha_prod_matrix.multiply(
+        var noisy_samples = sqrt_alpha_prod_matrix.multiply(
             original_samples
         ) + sqrt_one_minus_alpha_prod_matrix.multiply(noise)
         return noisy_samples

--- a/vae.mojo
+++ b/vae.mojo
@@ -15,7 +15,7 @@ struct Attention_Block:
         self.attention = other.attention
 
     fn forward(inout self, inout x: Matrix[float_dtype]) -> Matrix[float_dtype]:
-        let residue = x
+        var residue = x
         var out = self.group_norm.forward(x)
         out = out.reshape(x.dim0, x.dim1 * x.dim2, 1)
         out = out.transpose(0, 2)
@@ -102,13 +102,13 @@ struct Encoder:
     fn metrics_evals(
         self, matrix: Matrix[float_dtype], noise: Matrix[float_dtype]
     ) -> Matrix[float_dtype]:
-        let chunks = matrix.chunk(0, 2)
-        let mean = chunks[0]
+        var chunks = matrix.chunk(0, 2)
+        var mean = chunks[0]
         var log_variance = chunks[1]
         log_variance = log_variance.clamp(-30, 20)
-        let variance = log_variance.exp()
-        let std = variance.sqrt()
-        let out = mean + (noise.multiply(std))
+        var variance = log_variance.exp()
+        var std = variance.sqrt()
+        var out = mean + (noise.multiply(std))
         out *= 0.18215
         return out
 


### PR DESCRIPTION
Hi @lrmantovani10 These update the repo for Mojo 24.1.

I'm getting a segfault though on m2 macbook so might want to check this isn't breaking something that used to work.

Updates:
- Change `let` to `var`
- Change capacity to keyword-only argument
- Fix `vectorize` and `vectorize_unroll` signatures
- Fix `slice` now named `Slice`